### PR TITLE
resolve reconstruct proto

### DIFF
--- a/examples/psi/PSI_Client_Syft_Data_Scientist.ipynb
+++ b/examples/psi/PSI_Client_Syft_Data_Scientist.ipynb
@@ -46,7 +46,7 @@
       "♫♫♫ >\n",
       "♫♫♫ > ...waiting for response from OpenGrid Network... \u001b[92mDONE!\u001b[0m\n",
       "\n",
-      "♫♫♫ > Duet Client ID: \u001b[1m0ccc0c6688f95bd1026a3f25b76026c3\u001b[0m\n",
+      "♫♫♫ > Duet Client ID: \u001b[1mdb72748403e0819ec45679a3409b98fb\u001b[0m\n",
       "\n",
       "♫♫♫ > \u001b[95mSTEP 1:\u001b[0m Send the Duet Client ID to your duet partner!\n",
       "\n",
@@ -133,24 +133,28 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
+       "      <td>&lt;UID: e54e7463d432419ab2bca65355ef33b0&gt;</td>\n",
        "      <td>[reveal_intersection]</td>\n",
-       "      <td></td>\n",
+       "      <td>reveal intersection value</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
+       "      <td>&lt;UID: e608d7aa63a14a65af529a64c7b20b07&gt;</td>\n",
        "      <td>[fpr]</td>\n",
-       "      <td></td>\n",
+       "      <td>false positive rate</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                        ID                   Tags Description\n",
-       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
-       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            "
+       "                                        ID                   Tags  \\\n",
+       "0  <UID: e54e7463d432419ab2bca65355ef33b0>  [reveal_intersection]   \n",
+       "1  <UID: e608d7aa63a14a65af529a64c7b20b07>                  [fpr]   \n",
+       "\n",
+       "                 Description  \n",
+       "0  reveal intersection value  \n",
+       "1        false positive rate  "
       ]
      },
      "execution_count": 3,
@@ -221,29 +225,8 @@
    "outputs": [],
    "source": [
     "client_items = [\"Element \" + str(i) for i in range(1000)]\n",
-    "sy_client_items_len = sy.lib.python.Int(len(client_items)).tag(\"client_items_len\")\n",
-    "sy_client_items_len_ptr = sy_client_items_len.send(duet, searchable=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Goto --------> [Server-Step-2]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# [Client-Step-2]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## get setup message"
+    "sy_client_items_len = sy.lib.python.Int(len(client_items))\n",
+    "sy_client_items_len_ptr = sy_client_items_len.send(duet, searchable=True, tags=[\"client_items_len\"], description=\"client items length\")"
    ]
   },
   {
@@ -280,38 +263,36 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
+       "      <td>&lt;UID: e54e7463d432419ab2bca65355ef33b0&gt;</td>\n",
        "      <td>[reveal_intersection]</td>\n",
-       "      <td></td>\n",
+       "      <td>reveal intersection value</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
+       "      <td>&lt;UID: e608d7aa63a14a65af529a64c7b20b07&gt;</td>\n",
        "      <td>[fpr]</td>\n",
-       "      <td></td>\n",
+       "      <td>false positive rate</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>&lt;UID: 2512e06630c044cba620a27fb3831bb8&gt;</td>\n",
+       "      <td>&lt;UID: 9c3ad9fb648e463e9993083d93fb55a6&gt;</td>\n",
        "      <td>[client_items_len]</td>\n",
-       "      <td></td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>&lt;UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e&gt;</td>\n",
-       "      <td>[]</td>\n",
-       "      <td></td>\n",
+       "      <td>client items length</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                        ID                   Tags Description\n",
-       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
-       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            \n",
-       "2  <UID: 2512e06630c044cba620a27fb3831bb8>     [client_items_len]            \n",
-       "3  <UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e>                     []            "
+       "                                        ID                   Tags  \\\n",
+       "0  <UID: e54e7463d432419ab2bca65355ef33b0>  [reveal_intersection]   \n",
+       "1  <UID: e608d7aa63a14a65af529a64c7b20b07>                  [fpr]   \n",
+       "2  <UID: 9c3ad9fb648e463e9993083d93fb55a6>     [client_items_len]   \n",
+       "\n",
+       "                 Description  \n",
+       "0  reveal intersection value  \n",
+       "1        false positive rate  \n",
+       "2        client items length  "
       ]
      },
      "execution_count": 8,
@@ -324,14 +305,98 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Goto --------> [Server-Step-2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# [Client-Step-2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## get setup message"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>Tags</th>\n",
+       "      <th>Description</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>&lt;UID: e54e7463d432419ab2bca65355ef33b0&gt;</td>\n",
+       "      <td>[reveal_intersection]</td>\n",
+       "      <td>reveal intersection value</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>&lt;UID: e608d7aa63a14a65af529a64c7b20b07&gt;</td>\n",
+       "      <td>[fpr]</td>\n",
+       "      <td>false positive rate</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>&lt;UID: 9c3ad9fb648e463e9993083d93fb55a6&gt;</td>\n",
+       "      <td>[client_items_len]</td>\n",
+       "      <td>client items length</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>&lt;UID: 8a7f1b11926949d3be1df8341c719f8c&gt;</td>\n",
+       "      <td>[setup]</td>\n",
+       "      <td>psi.server Setup Message</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
       "text/plain": [
-       "'ed1bd1123b9845b4a2b9dcc1a3dbb94e'"
+       "                                        ID                   Tags  \\\n",
+       "0  <UID: e54e7463d432419ab2bca65355ef33b0>  [reveal_intersection]   \n",
+       "1  <UID: e608d7aa63a14a65af529a64c7b20b07>                  [fpr]   \n",
+       "2  <UID: 9c3ad9fb648e463e9993083d93fb55a6>     [client_items_len]   \n",
+       "3  <UID: 8a7f1b11926949d3be1df8341c719f8c>                [setup]   \n",
+       "\n",
+       "                 Description  \n",
+       "0  reveal intersection value  \n",
+       "1        false positive rate  \n",
+       "2        client items length  \n",
+       "3   psi.server Setup Message  "
       ]
      },
      "execution_count": 9,
@@ -340,8 +405,7 @@
     }
    ],
    "source": [
-    "id_str = str(duet.store[-1].id_at_location)[6:-1]\n",
-    "id_str"
+    "duet.store.pandas"
    ]
   },
   {
@@ -350,7 +414,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "setup_ptr = duet.store[id_str]"
+    "setup_ptr = duet.store[\"setup\"]"
    ]
   },
   {
@@ -412,7 +476,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "request_ptr = request.send(duet, tags=[\"request\"], searchable=True)"
+    "request_ptr = request.send(duet, tags=[\"request\"], searchable=True, description=\"client request\")"
    ]
   },
   {
@@ -449,45 +513,52 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
+       "      <td>&lt;UID: e54e7463d432419ab2bca65355ef33b0&gt;</td>\n",
        "      <td>[reveal_intersection]</td>\n",
-       "      <td></td>\n",
+       "      <td>reveal intersection value</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
+       "      <td>&lt;UID: e608d7aa63a14a65af529a64c7b20b07&gt;</td>\n",
        "      <td>[fpr]</td>\n",
-       "      <td></td>\n",
+       "      <td>false positive rate</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>&lt;UID: 2512e06630c044cba620a27fb3831bb8&gt;</td>\n",
+       "      <td>&lt;UID: 9c3ad9fb648e463e9993083d93fb55a6&gt;</td>\n",
        "      <td>[client_items_len]</td>\n",
-       "      <td></td>\n",
+       "      <td>client items length</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>&lt;UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e&gt;</td>\n",
-       "      <td>[]</td>\n",
-       "      <td></td>\n",
+       "      <td>&lt;UID: 8a7f1b11926949d3be1df8341c719f8c&gt;</td>\n",
+       "      <td>[setup]</td>\n",
+       "      <td>psi.server Setup Message</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>&lt;UID: 665a3f6445cd4c49b8130ccc6fa57441&gt;</td>\n",
-       "      <td>[]</td>\n",
-       "      <td></td>\n",
+       "      <td>&lt;UID: 9bfce48e8bca4d1cb359a2c9f66de7a8&gt;</td>\n",
+       "      <td>[request]</td>\n",
+       "      <td>client request</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                        ID                   Tags Description\n",
-       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
-       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            \n",
-       "2  <UID: 2512e06630c044cba620a27fb3831bb8>     [client_items_len]            \n",
-       "3  <UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e>                     []            \n",
-       "4  <UID: 665a3f6445cd4c49b8130ccc6fa57441>                     []            "
+       "                                        ID                   Tags  \\\n",
+       "0  <UID: e54e7463d432419ab2bca65355ef33b0>  [reveal_intersection]   \n",
+       "1  <UID: e608d7aa63a14a65af529a64c7b20b07>                  [fpr]   \n",
+       "2  <UID: 9c3ad9fb648e463e9993083d93fb55a6>     [client_items_len]   \n",
+       "3  <UID: 8a7f1b11926949d3be1df8341c719f8c>                [setup]   \n",
+       "4  <UID: 9bfce48e8bca4d1cb359a2c9f66de7a8>              [request]   \n",
+       "\n",
+       "                 Description  \n",
+       "0  reveal intersection value  \n",
+       "1        false positive rate  \n",
+       "2        client items length  \n",
+       "3   psi.server Setup Message  \n",
+       "4             client request  "
       ]
      },
      "execution_count": 15,
@@ -554,52 +625,60 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
+       "      <td>&lt;UID: e54e7463d432419ab2bca65355ef33b0&gt;</td>\n",
        "      <td>[reveal_intersection]</td>\n",
-       "      <td></td>\n",
+       "      <td>reveal intersection value</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
+       "      <td>&lt;UID: e608d7aa63a14a65af529a64c7b20b07&gt;</td>\n",
        "      <td>[fpr]</td>\n",
-       "      <td></td>\n",
+       "      <td>false positive rate</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>&lt;UID: 2512e06630c044cba620a27fb3831bb8&gt;</td>\n",
+       "      <td>&lt;UID: 9c3ad9fb648e463e9993083d93fb55a6&gt;</td>\n",
        "      <td>[client_items_len]</td>\n",
-       "      <td></td>\n",
+       "      <td>client items length</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>&lt;UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e&gt;</td>\n",
-       "      <td>[]</td>\n",
-       "      <td></td>\n",
+       "      <td>&lt;UID: 8a7f1b11926949d3be1df8341c719f8c&gt;</td>\n",
+       "      <td>[setup]</td>\n",
+       "      <td>psi.server Setup Message</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>&lt;UID: 665a3f6445cd4c49b8130ccc6fa57441&gt;</td>\n",
-       "      <td>[]</td>\n",
-       "      <td></td>\n",
+       "      <td>&lt;UID: 9bfce48e8bca4d1cb359a2c9f66de7a8&gt;</td>\n",
+       "      <td>[request]</td>\n",
+       "      <td>client request</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>&lt;UID: f51e2e738d6149d6b86305a68a6c678c&gt;</td>\n",
-       "      <td>[]</td>\n",
-       "      <td></td>\n",
+       "      <td>&lt;UID: d44d1570d9e44c8b9d426f36f64e377b&gt;</td>\n",
+       "      <td>[response]</td>\n",
+       "      <td>psi.server response</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                        ID                   Tags Description\n",
-       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
-       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            \n",
-       "2  <UID: 2512e06630c044cba620a27fb3831bb8>     [client_items_len]            \n",
-       "3  <UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e>                     []            \n",
-       "4  <UID: 665a3f6445cd4c49b8130ccc6fa57441>                     []            \n",
-       "5  <UID: f51e2e738d6149d6b86305a68a6c678c>                     []            "
+       "                                        ID                   Tags  \\\n",
+       "0  <UID: e54e7463d432419ab2bca65355ef33b0>  [reveal_intersection]   \n",
+       "1  <UID: e608d7aa63a14a65af529a64c7b20b07>                  [fpr]   \n",
+       "2  <UID: 9c3ad9fb648e463e9993083d93fb55a6>     [client_items_len]   \n",
+       "3  <UID: 8a7f1b11926949d3be1df8341c719f8c>                [setup]   \n",
+       "4  <UID: 9bfce48e8bca4d1cb359a2c9f66de7a8>              [request]   \n",
+       "5  <UID: d44d1570d9e44c8b9d426f36f64e377b>             [response]   \n",
+       "\n",
+       "                 Description  \n",
+       "0  reveal intersection value  \n",
+       "1        false positive rate  \n",
+       "2        client items length  \n",
+       "3   psi.server Setup Message  \n",
+       "4             client request  \n",
+       "5        psi.server response  "
       ]
      },
      "execution_count": 16,
@@ -615,35 +694,14 @@
    "cell_type": "code",
    "execution_count": 17,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'f51e2e738d6149d6b86305a68a6c678c'"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "id_str = str(duet.store[-1].id_at_location)[6:-1]\n",
-    "id_str"
+    "response_ptr = duet.store[\"response\"]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "response_ptr = duet.store[id_str]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -652,7 +710,7 @@
        "openmined_psi.GenerateProtobufWrapper.<locals>.ProtobufWrapper"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -670,7 +728,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -679,7 +737,7 @@
        "private_set_intersection.proto.psi_pb2.Response"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -698,7 +756,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -714,14 +772,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "500"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "if not reveal_intersection:\n",
     "    intersection = client.GetIntersectionSize(setup, response)\n",
     "    assert intersection >= (len(client_items) / 2.0)\n",
-    "    assert intersection <= (1.1 * len(client_items) / 2.0)"
+    "    assert intersection <= (1.1 * len(client_items) / 2.0)\n",
+    "intersection"
    ]
   }
  ],

--- a/examples/psi/PSI_Client_Syft_Data_Scientist.ipynb
+++ b/examples/psi/PSI_Client_Syft_Data_Scientist.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -42,11 +42,11 @@
       "♫♫♫ > \n",
       "\u001b[0m♫♫♫ >\n",
       "♫♫♫ > Punching through firewall to OpenGrid Network Node at:\n",
-      "♫♫♫ > http://ec2-18-216-8-163.us-east-2.compute.amazonaws.com:5000\n",
+      "♫♫♫ > http://localhost:5000\n",
       "♫♫♫ >\n",
       "♫♫♫ > ...waiting for response from OpenGrid Network... \u001b[92mDONE!\u001b[0m\n",
       "\n",
-      "♫♫♫ > Duet Client ID: \u001b[1m4c6c498d3139bfe7dc124cb0de4b9c5f\u001b[0m\n",
+      "♫♫♫ > Duet Client ID: \u001b[1m0ccc0c6688f95bd1026a3f25b76026c3\u001b[0m\n",
       "\n",
       "♫♫♫ > \u001b[95mSTEP 1:\u001b[0m Send the Duet Client ID to your duet partner!\n",
       "\n",
@@ -59,12 +59,12 @@
    ],
    "source": [
     "import syft as sy\n",
-    "duet = sy.join_duet(loopback=True)"
+    "duet = sy.join_duet(network_url=\"http://localhost:5000\", loopback=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,363 +72,36 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 4,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "Empty DataFrame\n",
-       "Columns: []\n",
-       "Index: []"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
-    "# WAIT to run Server Notebook first\n",
-    "duet.store.pandas"
+    "from: https://github.com/OpenMined/PSI/blob/master/private_set_intersection/python/tests.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Goto --------> [server-step-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# [Client-Step-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## get reveal_intersection"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# from: https://github.com/OpenMined/PSI/blob/master/private_set_intersection/python/tests.py"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reveal_intersection_ptr = duet.store[\"reveal_intersection\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "reveal_intersection = reveal_intersection_ptr.get(\n",
-    "    request_block=True,\n",
-    "    name=\"reveal_intersection\",\n",
-    "    reason=\"Are we revealing or not?\",\n",
-    "    timeout_secs=10,\n",
-    "    delete_obj=False\n",
-    ")\n",
-    "reveal_intersection"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "client = psi.client.CreateWithNewKey(reveal_intersection)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "client_items = [\"Element \" + str(i) for i in range(1000)]\n",
-    "sy_client_items_len = sy.lib.python.Int(len(client_items)).tag(\"client_items_len\")\n",
-    "sy_client_items_len_ptr = sy_client_items_len.send(duet, searchable=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# STOP and run Server Notebook again"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "setup_ptr = duet.store[\"3a6d9e21227e4e9bb6ac69a278be74be\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# TODO make setup serializable\n",
-    "setup_wrapper = setup_ptr.get(\n",
-    "    request_block=True,\n",
-    "    name=\"setup\",\n",
-    "    reason=\"To get the setup\",\n",
-    "    timeout_secs=10,\n",
-    "    delete_obj=False\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "openmined_psi.GenerateProtobufWrapper.<locals>.ProtobufWrapper"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# make this return the protobuf somehow?\n",
-    "type(setup_wrapper)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wrapper_data = setup_wrapper.data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "proto.core.store.store_object_pb2.StorableObject"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "type(wrapper_data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'openmined_psi.ServerSetupProtobufWrapper'"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# make this return the real reinflated protobuf\n",
-    "wrapper_data.obj_type"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "setup_bytes = wrapper_data.data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "google.protobuf.any_pb2.Any"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "type(setup_bytes)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x = wrapper_data.data.value"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "bytes"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "type(x)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# msg.ParseFromString(wrapper_data.data.value)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "request = client.CreateRequest(client_items)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "private_set_intersection.proto.psi_pb2.Request"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "type(request)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "_data_object2proto <class 'private_set_intersection.proto.psi_pb2.Request'> <class 'private_set_intersection.proto.psi_pb2.Request'>\n"
-     ]
-    }
-   ],
-   "source": [
-    "# # TODO: make openmined_psi.proto_request serializable\n",
-    "# response_ptr = server_ptr.ProcessRequest(request)\n",
-    "\n",
-    "request_ptr = request.send(duet, tags=[\"request\"], searchable=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<UID: 50e1b0268ab24737a26fcb5b7c13cadc>"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "request_ptr.id_at_location"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -460,32 +133,14 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>&lt;UID: c2fff91e4de84a9ebf187b6b35b179f9&gt;</td>\n",
+       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
        "      <td>[reveal_intersection]</td>\n",
        "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>&lt;UID: 6169e798788a46c5a8625f046cda96e2&gt;</td>\n",
+       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
        "      <td>[fpr]</td>\n",
-       "      <td></td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>&lt;UID: 7f9ec1f3c36048cc978d31f0778b865b&gt;</td>\n",
-       "      <td>[client_items_len]</td>\n",
-       "      <td></td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>&lt;UID: 3a6d9e21227e4e9bb6ac69a278be74be&gt;</td>\n",
-       "      <td>[]</td>\n",
-       "      <td></td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>&lt;UID: 50e1b0268ab24737a26fcb5b7c13cadc&gt;</td>\n",
-       "      <td>[]</td>\n",
        "      <td></td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -494,14 +149,11 @@
       ],
       "text/plain": [
        "                                        ID                   Tags Description\n",
-       "0  <UID: c2fff91e4de84a9ebf187b6b35b179f9>  [reveal_intersection]            \n",
-       "1  <UID: 6169e798788a46c5a8625f046cda96e2>                  [fpr]            \n",
-       "2  <UID: 7f9ec1f3c36048cc978d31f0778b865b>     [client_items_len]            \n",
-       "3  <UID: 3a6d9e21227e4e9bb6ac69a278be74be>                     []            \n",
-       "4  <UID: 50e1b0268ab24737a26fcb5b7c13cadc>                     []            "
+       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
+       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            "
       ]
      },
-     "execution_count": 27,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -512,22 +164,541 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# TODO make openmined_psi.proto_response serializable\n",
-    "response = response_ptr.get(\n",
+    "reveal_intersection_ptr = duet.store[\"reveal_intersection\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "reveal_intersection = reveal_intersection_ptr.get(\n",
     "    request_block=True,\n",
-    "    name=\"reponse\",\n",
-    "    reason=\"To get the result\",\n",
+    "    name=\"reveal_intersection\",\n",
+    "    reason=\"Are we revealing or not?\",\n",
     "    timeout_secs=10,\n",
+    "    delete_obj=False\n",
+    ")\n",
+    "reveal_intersection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## send client_items_len"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = psi.client.CreateWithNewKey(reveal_intersection)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client_items = [\"Element \" + str(i) for i in range(1000)]\n",
+    "sy_client_items_len = sy.lib.python.Int(len(client_items)).tag(\"client_items_len\")\n",
+    "sy_client_items_len_ptr = sy_client_items_len.send(duet, searchable=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Goto --------> [Server-Step-2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# [Client-Step-2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## get setup message"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>Tags</th>\n",
+       "      <th>Description</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
+       "      <td>[reveal_intersection]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
+       "      <td>[fpr]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>&lt;UID: 2512e06630c044cba620a27fb3831bb8&gt;</td>\n",
+       "      <td>[client_items_len]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>&lt;UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e&gt;</td>\n",
+       "      <td>[]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                        ID                   Tags Description\n",
+       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
+       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            \n",
+       "2  <UID: 2512e06630c044cba620a27fb3831bb8>     [client_items_len]            \n",
+       "3  <UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e>                     []            "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "duet.store.pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ed1bd1123b9845b4a2b9dcc1a3dbb94e'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "id_str = str(duet.store[-1].id_at_location)[6:-1]\n",
+    "id_str"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "setup_ptr = duet.store[id_str]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO make setup serializable\n",
+    "setup_wrapper = setup_ptr.get(\n",
+    "    request_block=True,\n",
+    "    name=\"setup\",\n",
+    "    reason=\"To get the setup\",\n",
+    "    timeout_secs=10,\n",
+    "    delete_obj=False\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "private_set_intersection.proto.psi_pb2.ServerSetup"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "setup = setup_wrapper.data\n",
+    "type(setup)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## send request"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "request = client.CreateRequest(client_items)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "request_ptr = request.send(duet, tags=[\"request\"], searchable=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>Tags</th>\n",
+       "      <th>Description</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
+       "      <td>[reveal_intersection]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
+       "      <td>[fpr]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>&lt;UID: 2512e06630c044cba620a27fb3831bb8&gt;</td>\n",
+       "      <td>[client_items_len]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>&lt;UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e&gt;</td>\n",
+       "      <td>[]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>&lt;UID: 665a3f6445cd4c49b8130ccc6fa57441&gt;</td>\n",
+       "      <td>[]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                        ID                   Tags Description\n",
+       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
+       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            \n",
+       "2  <UID: 2512e06630c044cba620a27fb3831bb8>     [client_items_len]            \n",
+       "3  <UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e>                     []            \n",
+       "4  <UID: 665a3f6445cd4c49b8130ccc6fa57441>                     []            "
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "duet.store.pandas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Goto --------> [Server-Step-3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# [Client-Step-3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## get response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>Tags</th>\n",
+       "      <th>Description</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
+       "      <td>[reveal_intersection]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
+       "      <td>[fpr]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>&lt;UID: 2512e06630c044cba620a27fb3831bb8&gt;</td>\n",
+       "      <td>[client_items_len]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>&lt;UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e&gt;</td>\n",
+       "      <td>[]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>&lt;UID: 665a3f6445cd4c49b8130ccc6fa57441&gt;</td>\n",
+       "      <td>[]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>&lt;UID: f51e2e738d6149d6b86305a68a6c678c&gt;</td>\n",
+       "      <td>[]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                        ID                   Tags Description\n",
+       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
+       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            \n",
+       "2  <UID: 2512e06630c044cba620a27fb3831bb8>     [client_items_len]            \n",
+       "3  <UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e>                     []            \n",
+       "4  <UID: 665a3f6445cd4c49b8130ccc6fa57441>                     []            \n",
+       "5  <UID: f51e2e738d6149d6b86305a68a6c678c>                     []            "
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "duet.store.pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'f51e2e738d6149d6b86305a68a6c678c'"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "id_str = str(duet.store[-1].id_at_location)[6:-1]\n",
+    "id_str"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response_ptr = duet.store[id_str]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "openmined_psi.GenerateProtobufWrapper.<locals>.ProtobufWrapper"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# TODO make openmined_psi.proto_response serializable\n",
+    "response_wrapper = response_ptr.get(\n",
+    "    request_block=True,\n",
+    "    name=\"response\",\n",
+    "    reason=\"To get the response\",\n",
+    "    timeout_secs=10,\n",
+    ")\n",
+    "type(response_wrapper)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "private_set_intersection.proto.psi_pb2.Response"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response = response_wrapper.data\n",
+    "type(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## get result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -543,7 +714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -551,15 +722,6 @@
     "    intersection = client.GetIntersectionSize(setup, response)\n",
     "    assert intersection >= (len(client_items) / 2.0)\n",
     "    assert intersection <= (1.1 * len(client_items) / 2.0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "duet.store.pandas"
    ]
   }
  ],
@@ -579,7 +741,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/psi/PSI_Server_Syft_Data_Owner.ipynb
+++ b/examples/psi/PSI_Server_Syft_Data_Owner.ipynb
@@ -47,7 +47,7 @@
       "♫♫♫ > \u001b[95mSTEP 1:\u001b[0m Send the following code to your Duet Partner!\n",
       "\n",
       "import syft as sy\n",
-      "duet = sy.duet(\"\u001b[1m30528ca86b978859b43f64696621dcae\u001b[0m\")\n",
+      "duet = sy.duet(\"\u001b[1m2db5a2ab69cbe6c0d463061765ebafb1\u001b[0m\")\n",
       "\n",
       "♫♫♫ > \u001b[95mSTEP 2:\u001b[0m Running the code above will print out a 'Client ID'.\n",
       "♫♫♫ >         Have your duet partner send it to you and enter it below!\n",
@@ -58,7 +58,7 @@
       "\n",
       "♫♫♫ > \u001b[92mCONNECTED!\u001b[0m\n",
       "\n",
-      "♫♫♫ > DUET LIVE STATUS  -  Objects: 5  Requests: 0   Messages: 38                                "
+      "♫♫♫ > DUET LIVE STATUS  *  Objects: 5  Requests: 0   Messages: 37                                "
      ]
     }
    ],
@@ -112,7 +112,7 @@
     ")\n",
     "\n",
     "sy_reveal_intersection = sy.lib.python.Bool(reveal_intersection)\n",
-    "sy_reveal_intersection_ptr = sy_reveal_intersection.tag(\"reveal_intersection\").send(duet, searchable=True)"
+    "sy_reveal_intersection_ptr = sy_reveal_intersection.send(duet, searchable=True, tags=[\"reveal_intersection\"], description=\"reveal intersection value\")"
    ]
   },
   {
@@ -149,17 +149,20 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
+       "      <td>&lt;UID: e54e7463d432419ab2bca65355ef33b0&gt;</td>\n",
        "      <td>[reveal_intersection]</td>\n",
-       "      <td></td>\n",
+       "      <td>reveal intersection value</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                        ID                   Tags Description\n",
-       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            "
+       "                                        ID                   Tags  \\\n",
+       "0  <UID: e54e7463d432419ab2bca65355ef33b0>  [reveal_intersection]   \n",
+       "\n",
+       "                 Description  \n",
+       "0  reveal intersection value  "
       ]
      },
      "execution_count": 5,
@@ -192,7 +195,7 @@
     "    action=\"accept\"\n",
     ")\n",
     "sy_fpr = sy.lib.python.Float(fpr)\n",
-    "sy_fpr_ptr = sy_fpr.tag(\"fpr\").send(duet, searchable=True)"
+    "sy_fpr_ptr = sy_fpr.send(duet, searchable=True, tags=[\"fpr\"], description=\"false positive rate\")"
    ]
   },
   {
@@ -229,24 +232,28 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
+       "      <td>&lt;UID: e54e7463d432419ab2bca65355ef33b0&gt;</td>\n",
        "      <td>[reveal_intersection]</td>\n",
-       "      <td></td>\n",
+       "      <td>reveal intersection value</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
+       "      <td>&lt;UID: e608d7aa63a14a65af529a64c7b20b07&gt;</td>\n",
        "      <td>[fpr]</td>\n",
-       "      <td></td>\n",
+       "      <td>false positive rate</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                        ID                   Tags Description\n",
-       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
-       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            "
+       "                                        ID                   Tags  \\\n",
+       "0  <UID: e54e7463d432419ab2bca65355ef33b0>  [reveal_intersection]   \n",
+       "1  <UID: e608d7aa63a14a65af529a64c7b20b07>                  [fpr]   \n",
+       "\n",
+       "                 Description  \n",
+       "0  reveal intersection value  \n",
+       "1        false positive rate  "
       ]
      },
      "execution_count": 7,
@@ -354,7 +361,7 @@
    "source": [
     "# TODO fix issue where we cant set tags or description\n",
     "# these could be getting lost on the ProtobufWrapper StorableObject\n",
-    "setup_ptr = setup.send(duet, searchable=True, tags=[\"setup\"], description=\"psi.server Setup\")"
+    "setup_ptr = setup.send(duet, searchable=True, tags=[\"setup\"], description=\"psi.server Setup Message\")"
    ]
   },
   {
@@ -391,38 +398,44 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
+       "      <td>&lt;UID: e54e7463d432419ab2bca65355ef33b0&gt;</td>\n",
        "      <td>[reveal_intersection]</td>\n",
-       "      <td></td>\n",
+       "      <td>reveal intersection value</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
+       "      <td>&lt;UID: e608d7aa63a14a65af529a64c7b20b07&gt;</td>\n",
        "      <td>[fpr]</td>\n",
-       "      <td></td>\n",
+       "      <td>false positive rate</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>&lt;UID: 2512e06630c044cba620a27fb3831bb8&gt;</td>\n",
+       "      <td>&lt;UID: 9c3ad9fb648e463e9993083d93fb55a6&gt;</td>\n",
        "      <td>[client_items_len]</td>\n",
-       "      <td></td>\n",
+       "      <td>client items length</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>&lt;UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e&gt;</td>\n",
-       "      <td>[]</td>\n",
-       "      <td></td>\n",
+       "      <td>&lt;UID: 8a7f1b11926949d3be1df8341c719f8c&gt;</td>\n",
+       "      <td>[setup]</td>\n",
+       "      <td>psi.server Setup Message</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                        ID                   Tags Description\n",
-       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
-       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            \n",
-       "2  <UID: 2512e06630c044cba620a27fb3831bb8>     [client_items_len]            \n",
-       "3  <UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e>                     []            "
+       "                                        ID                   Tags  \\\n",
+       "0  <UID: e54e7463d432419ab2bca65355ef33b0>  [reveal_intersection]   \n",
+       "1  <UID: e608d7aa63a14a65af529a64c7b20b07>                  [fpr]   \n",
+       "2  <UID: 9c3ad9fb648e463e9993083d93fb55a6>     [client_items_len]   \n",
+       "3  <UID: 8a7f1b11926949d3be1df8341c719f8c>                [setup]   \n",
+       "\n",
+       "                 Description  \n",
+       "0  reveal intersection value  \n",
+       "1        false positive rate  \n",
+       "2        client items length  \n",
+       "3   psi.server Setup Message  "
       ]
      },
      "execution_count": 14,
@@ -489,45 +502,52 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
+       "      <td>&lt;UID: e54e7463d432419ab2bca65355ef33b0&gt;</td>\n",
        "      <td>[reveal_intersection]</td>\n",
-       "      <td></td>\n",
+       "      <td>reveal intersection value</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
+       "      <td>&lt;UID: e608d7aa63a14a65af529a64c7b20b07&gt;</td>\n",
        "      <td>[fpr]</td>\n",
-       "      <td></td>\n",
+       "      <td>false positive rate</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>&lt;UID: 2512e06630c044cba620a27fb3831bb8&gt;</td>\n",
+       "      <td>&lt;UID: 9c3ad9fb648e463e9993083d93fb55a6&gt;</td>\n",
        "      <td>[client_items_len]</td>\n",
-       "      <td></td>\n",
+       "      <td>client items length</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>&lt;UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e&gt;</td>\n",
-       "      <td>[]</td>\n",
-       "      <td></td>\n",
+       "      <td>&lt;UID: 8a7f1b11926949d3be1df8341c719f8c&gt;</td>\n",
+       "      <td>[setup]</td>\n",
+       "      <td>psi.server Setup Message</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>&lt;UID: 665a3f6445cd4c49b8130ccc6fa57441&gt;</td>\n",
-       "      <td>[]</td>\n",
-       "      <td></td>\n",
+       "      <td>&lt;UID: 9bfce48e8bca4d1cb359a2c9f66de7a8&gt;</td>\n",
+       "      <td>[request]</td>\n",
+       "      <td>client request</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                        ID                   Tags Description\n",
-       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
-       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            \n",
-       "2  <UID: 2512e06630c044cba620a27fb3831bb8>     [client_items_len]            \n",
-       "3  <UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e>                     []            \n",
-       "4  <UID: 665a3f6445cd4c49b8130ccc6fa57441>                     []            "
+       "                                        ID                   Tags  \\\n",
+       "0  <UID: e54e7463d432419ab2bca65355ef33b0>  [reveal_intersection]   \n",
+       "1  <UID: e608d7aa63a14a65af529a64c7b20b07>                  [fpr]   \n",
+       "2  <UID: 9c3ad9fb648e463e9993083d93fb55a6>     [client_items_len]   \n",
+       "3  <UID: 8a7f1b11926949d3be1df8341c719f8c>                [setup]   \n",
+       "4  <UID: 9bfce48e8bca4d1cb359a2c9f66de7a8>              [request]   \n",
+       "\n",
+       "                 Description  \n",
+       "0  reveal intersection value  \n",
+       "1        false positive rate  \n",
+       "2        client items length  \n",
+       "3   psi.server Setup Message  \n",
+       "4             client request  "
       ]
      },
      "execution_count": 15,
@@ -543,21 +563,9 @@
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'665a3f6445cd4c49b8130ccc6fa57441'"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "id_str = str(duet.store[-1].id_at_location)[6:-1]\n",
-    "id_str"
+    "request_ptr = duet.store[\"request\"]"
    ]
   },
   {
@@ -566,21 +574,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "request_ptr = duet.store[id_str]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "request_wrapper = request_ptr.get(delete_obj=False)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -596,7 +595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -605,7 +604,7 @@
        "private_set_intersection.proto.psi_pb2.Response"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -617,7 +616,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -629,7 +628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -638,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -670,55 +669,63 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
+       "      <td>&lt;UID: e54e7463d432419ab2bca65355ef33b0&gt;</td>\n",
        "      <td>[reveal_intersection]</td>\n",
-       "      <td></td>\n",
+       "      <td>reveal intersection value</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
+       "      <td>&lt;UID: e608d7aa63a14a65af529a64c7b20b07&gt;</td>\n",
        "      <td>[fpr]</td>\n",
-       "      <td></td>\n",
+       "      <td>false positive rate</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>&lt;UID: 2512e06630c044cba620a27fb3831bb8&gt;</td>\n",
+       "      <td>&lt;UID: 9c3ad9fb648e463e9993083d93fb55a6&gt;</td>\n",
        "      <td>[client_items_len]</td>\n",
-       "      <td></td>\n",
+       "      <td>client items length</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>&lt;UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e&gt;</td>\n",
-       "      <td>[]</td>\n",
-       "      <td></td>\n",
+       "      <td>&lt;UID: 8a7f1b11926949d3be1df8341c719f8c&gt;</td>\n",
+       "      <td>[setup]</td>\n",
+       "      <td>psi.server Setup Message</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>&lt;UID: 665a3f6445cd4c49b8130ccc6fa57441&gt;</td>\n",
-       "      <td>[]</td>\n",
-       "      <td></td>\n",
+       "      <td>&lt;UID: 9bfce48e8bca4d1cb359a2c9f66de7a8&gt;</td>\n",
+       "      <td>[request]</td>\n",
+       "      <td>client request</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>&lt;UID: f51e2e738d6149d6b86305a68a6c678c&gt;</td>\n",
-       "      <td>[]</td>\n",
-       "      <td></td>\n",
+       "      <td>&lt;UID: d44d1570d9e44c8b9d426f36f64e377b&gt;</td>\n",
+       "      <td>[response]</td>\n",
+       "      <td>psi.server response</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                        ID                   Tags Description\n",
-       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
-       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            \n",
-       "2  <UID: 2512e06630c044cba620a27fb3831bb8>     [client_items_len]            \n",
-       "3  <UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e>                     []            \n",
-       "4  <UID: 665a3f6445cd4c49b8130ccc6fa57441>                     []            \n",
-       "5  <UID: f51e2e738d6149d6b86305a68a6c678c>                     []            "
+       "                                        ID                   Tags  \\\n",
+       "0  <UID: e54e7463d432419ab2bca65355ef33b0>  [reveal_intersection]   \n",
+       "1  <UID: e608d7aa63a14a65af529a64c7b20b07>                  [fpr]   \n",
+       "2  <UID: 9c3ad9fb648e463e9993083d93fb55a6>     [client_items_len]   \n",
+       "3  <UID: 8a7f1b11926949d3be1df8341c719f8c>                [setup]   \n",
+       "4  <UID: 9bfce48e8bca4d1cb359a2c9f66de7a8>              [request]   \n",
+       "5  <UID: d44d1570d9e44c8b9d426f36f64e377b>             [response]   \n",
+       "\n",
+       "                 Description  \n",
+       "0  reveal intersection value  \n",
+       "1        false positive rate  \n",
+       "2        client items length  \n",
+       "3   psi.server Setup Message  \n",
+       "4             client request  \n",
+       "5        psi.server response  "
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/psi/PSI_Server_Syft_Data_Owner.ipynb
+++ b/examples/psi/PSI_Server_Syft_Data_Owner.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -40,14 +40,14 @@
       "♫♫♫ >             Use at your own risk.\n",
       "\u001b[0m♫♫♫ >\n",
       "♫♫♫ > Punching through firewall to OpenGrid Network Node at:\n",
-      "♫♫♫ > http://ec2-18-216-8-163.us-east-2.compute.amazonaws.com:5000\n",
+      "♫♫♫ > http://localhost:5000\n",
       "♫♫♫ >\n",
       "♫♫♫ > ...waiting for response from OpenGrid Network... \u001b[92mDONE!\u001b[0m\n",
       "♫♫♫ >\n",
       "♫♫♫ > \u001b[95mSTEP 1:\u001b[0m Send the following code to your Duet Partner!\n",
       "\n",
       "import syft as sy\n",
-      "duet = sy.duet(\"\u001b[1m4d513134abbaa0ec0457da04535cd3e9\u001b[0m\")\n",
+      "duet = sy.duet(\"\u001b[1m30528ca86b978859b43f64696621dcae\u001b[0m\")\n",
       "\n",
       "♫♫♫ > \u001b[95mSTEP 2:\u001b[0m Running the code above will print out a 'Client ID'.\n",
       "♫♫♫ >         Have your duet partner send it to you and enter it below!\n",
@@ -58,14 +58,37 @@
       "\n",
       "♫♫♫ > \u001b[92mCONNECTED!\u001b[0m\n",
       "\n",
-      "♫♫♫ > DUET LIVE STATUS  *  Objects: 6  Requests: 0   Messages: 36                                "
+      "♫♫♫ > DUET LIVE STATUS  -  Objects: 5  Requests: 0   Messages: 38                                "
      ]
     }
    ],
    "source": [
     "import syft as sy\n",
-    "duet = sy.launch_duet(loopback=True)\n",
+    "duet = sy.launch_duet(network_url=\"http://localhost:5000\", loopback=True)\n",
     "sy.logging(file_path=\"./syft_do.log\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openmined_psi as psi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# [Server-Step-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## send reveal_intersection"
    ]
   },
   {
@@ -74,30 +97,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import openmined_psi as psi"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# START"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "reveal_intersection = False"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,24 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# allow the client to access the false positive rate\n",
-    "fpr=1e-6\n",
-    "\n",
-    "duet.requests.add_handler(\n",
-    "    name=\"fpr\",\n",
-    "    action=\"accept\"\n",
-    ")\n",
-    "sy_fpr = sy.lib.python.Float(fpr)\n",
-    "sy_fpr_ptr = sy_fpr.tag(\"fpr\").send(duet, searchable=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -161,13 +149,93 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>&lt;UID: c2fff91e4de84a9ebf187b6b35b179f9&gt;</td>\n",
+       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
+       "      <td>[reveal_intersection]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                        ID                   Tags Description\n",
+       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "duet.store.pandas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## send fpr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# allow the client to access the false positive rate\n",
+    "fpr=1e-6\n",
+    "\n",
+    "duet.requests.add_handler(\n",
+    "    name=\"fpr\",\n",
+    "    action=\"accept\"\n",
+    ")\n",
+    "sy_fpr = sy.lib.python.Float(fpr)\n",
+    "sy_fpr_ptr = sy_fpr.tag(\"fpr\").send(duet, searchable=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>Tags</th>\n",
+       "      <th>Description</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
        "      <td>[reveal_intersection]</td>\n",
        "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>&lt;UID: 6169e798788a46c5a8625f046cda96e2&gt;</td>\n",
+       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
        "      <td>[fpr]</td>\n",
        "      <td></td>\n",
        "    </tr>\n",
@@ -177,17 +245,54 @@
       ],
       "text/plain": [
        "                                        ID                   Tags Description\n",
-       "0  <UID: c2fff91e4de84a9ebf187b6b35b179f9>  [reveal_intersection]            \n",
-       "1  <UID: 6169e798788a46c5a8625f046cda96e2>                  [fpr]            "
+       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
+       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            "
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "duet.store.pandas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Goto --------> [Client-Step-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# [Server-Step-2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## get client_items_len"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client_items_len = duet.store[\"client_items_len\"].get(delete_obj=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## send setup message"
    ]
   },
   {
@@ -205,7 +310,40 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# STOP and run Client Notebook"
+    "server = psi.server.CreateWithNewKey(reveal_intersection)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "private_set_intersection.proto.psi_pb2.ServerSetup"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "setup = server.CreateSetupMessage(fpr, client_items_len, server_items)\n",
+    "type(setup)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "duet.requests.add_handler(\n",
+    "    name=\"setup\",\n",
+    "    action=\"accept\"\n",
+    ")"
    ]
   },
   {
@@ -214,11 +352,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "duet.requests.add_handler(\n",
-    "    name=\"setup\",\n",
-    "    action=\"accept\"\n",
-    ")\n",
-    "client_items_len = duet.store[\"client_items_len\"].get(delete_obj=False)"
+    "# TODO fix issue where we cant set tags or description\n",
+    "# these could be getting lost on the ProtobufWrapper StorableObject\n",
+    "setup_ptr = setup.send(duet, searchable=True, tags=[\"setup\"], description=\"psi.server Setup\")"
    ]
   },
   {
@@ -228,8 +364,65 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>Tags</th>\n",
+       "      <th>Description</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
+       "      <td>[reveal_intersection]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
+       "      <td>[fpr]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>&lt;UID: 2512e06630c044cba620a27fb3831bb8&gt;</td>\n",
+       "      <td>[client_items_len]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>&lt;UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e&gt;</td>\n",
+       "      <td>[]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
       "text/plain": [
-       "(float, syft.lib.python.Int, list)"
+       "                                        ID                   Tags Description\n",
+       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
+       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            \n",
+       "2  <UID: 2512e06630c044cba620a27fb3831bb8>     [client_items_len]            \n",
+       "3  <UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e>                     []            "
       ]
      },
      "execution_count": 14,
@@ -238,16 +431,112 @@
     }
    ],
    "source": [
-    "type(fpr), type(client_items_len), type(server_items)"
+    "duet.store.pandas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Goto --------> [Client-Step-2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# [Server-Step-3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## get request"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>Tags</th>\n",
+       "      <th>Description</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
+       "      <td>[reveal_intersection]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
+       "      <td>[fpr]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>&lt;UID: 2512e06630c044cba620a27fb3831bb8&gt;</td>\n",
+       "      <td>[client_items_len]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>&lt;UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e&gt;</td>\n",
+       "      <td>[]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>&lt;UID: 665a3f6445cd4c49b8130ccc6fa57441&gt;</td>\n",
+       "      <td>[]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                        ID                   Tags Description\n",
+       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
+       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            \n",
+       "2  <UID: 2512e06630c044cba620a27fb3831bb8>     [client_items_len]            \n",
+       "3  <UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e>                     []            \n",
+       "4  <UID: 665a3f6445cd4c49b8130ccc6fa57441>                     []            "
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "server = psi.server.CreateWithNewKey(reveal_intersection)"
+    "duet.store.pandas"
    ]
   },
   {
@@ -256,144 +545,95 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "got these <class 'openmined_psi.server'> <class 'float'> <class 'syft.lib.python.Int'> <class 'list'>\n"
-     ]
+     "data": {
+      "text/plain": [
+       "'665a3f6445cd4c49b8130ccc6fa57441'"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "setup = server.CreateSetupMessage(fpr, client_items_len, server_items)"
+    "id_str = str(duet.store[-1].id_at_location)[6:-1]\n",
+    "id_str"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 17,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['BloomFilterInfo',\n",
-       " 'ByteSize',\n",
-       " 'Clear',\n",
-       " 'ClearExtension',\n",
-       " 'ClearField',\n",
-       " 'CopyFrom',\n",
-       " 'DESCRIPTOR',\n",
-       " 'DiscardUnknownFields',\n",
-       " 'Extensions',\n",
-       " 'FindInitializationErrors',\n",
-       " 'FromString',\n",
-       " 'GCSInfo',\n",
-       " 'HasExtension',\n",
-       " 'HasField',\n",
-       " 'IsInitialized',\n",
-       " 'ListFields',\n",
-       " 'MergeFrom',\n",
-       " 'MergeFromString',\n",
-       " 'ParseFromString',\n",
-       " 'RegisterExtension',\n",
-       " 'SerializePartialToString',\n",
-       " 'SerializeToString',\n",
-       " 'SetInParent',\n",
-       " 'UnknownFields',\n",
-       " 'WhichOneof',\n",
-       " '_CheckCalledFromGeneratedFile',\n",
-       " '_SetListener',\n",
-       " '__class__',\n",
-       " '__deepcopy__',\n",
-       " '__delattr__',\n",
-       " '__dir__',\n",
-       " '__doc__',\n",
-       " '__eq__',\n",
-       " '__format__',\n",
-       " '__ge__',\n",
-       " '__getattribute__',\n",
-       " '__getstate__',\n",
-       " '__gt__',\n",
-       " '__hash__',\n",
-       " '__init__',\n",
-       " '__init_subclass__',\n",
-       " '__le__',\n",
-       " '__lt__',\n",
-       " '__module__',\n",
-       " '__ne__',\n",
-       " '__new__',\n",
-       " '__reduce__',\n",
-       " '__reduce_ex__',\n",
-       " '__repr__',\n",
-       " '__setattr__',\n",
-       " '__setstate__',\n",
-       " '__sizeof__',\n",
-       " '__slots__',\n",
-       " '__str__',\n",
-       " '__subclasshook__',\n",
-       " '__unicode__',\n",
-       " '_extensions_by_name',\n",
-       " '_extensions_by_number',\n",
-       " '_to_bytes',\n",
-       " 'bits',\n",
-       " 'bloom_filter',\n",
-       " 'describe',\n",
-       " 'gcs',\n",
-       " 'proto',\n",
-       " 'send',\n",
-       " 'send_to',\n",
-       " 'serializable_wrapper_type',\n",
-       " 'serialize',\n",
-       " 'tag',\n",
-       " 'to_bytes',\n",
-       " 'to_proto']"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "dir(setup)"
+    "request_ptr = duet.store[id_str]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 18,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "_data_object2proto <class 'private_set_intersection.proto.psi_pb2.ServerSetup'> <class 'private_set_intersection.proto.psi_pb2.ServerSetup'>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# TODO fix issue where we cant set tags or description\n",
-    "# these could be getting lost on the ProtobufWrapper StorableObject\n",
-    "setup_ptr = setup.send(duet, searchable=True, tags=[\"setup\"], description=\"psi.server Setup\")"
+    "request_wrapper = request_ptr.get(delete_obj=False)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 19,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "request = request_wrapper.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## send response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<UID: 3a6d9e21227e4e9bb6ac69a278be74be>"
+       "private_set_intersection.proto.psi_pb2.Response"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "setup_ptr.id_at_location"
+    "response = server.ProcessRequest(request)\n",
+    "type(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "duet.requests.add_handler(\n",
+    "    name=\"response\",\n",
+    "    action=\"accept\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response_ptr = response.send(duet, searchable=True, tags=[\"response\"], description=\"psi.server response\")"
    ]
   },
   {
@@ -430,31 +670,37 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>&lt;UID: c2fff91e4de84a9ebf187b6b35b179f9&gt;</td>\n",
+       "      <td>&lt;UID: e9f28b44083e4919b5e674e2791a7367&gt;</td>\n",
        "      <td>[reveal_intersection]</td>\n",
        "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>&lt;UID: 6169e798788a46c5a8625f046cda96e2&gt;</td>\n",
+       "      <td>&lt;UID: eecc06f86a584b2e978b34fcce490775&gt;</td>\n",
        "      <td>[fpr]</td>\n",
        "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>&lt;UID: 7f9ec1f3c36048cc978d31f0778b865b&gt;</td>\n",
+       "      <td>&lt;UID: 2512e06630c044cba620a27fb3831bb8&gt;</td>\n",
        "      <td>[client_items_len]</td>\n",
        "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>&lt;UID: 3a6d9e21227e4e9bb6ac69a278be74be&gt;</td>\n",
+       "      <td>&lt;UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e&gt;</td>\n",
        "      <td>[]</td>\n",
        "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>&lt;UID: 50e1b0268ab24737a26fcb5b7c13cadc&gt;</td>\n",
+       "      <td>&lt;UID: 665a3f6445cd4c49b8130ccc6fa57441&gt;</td>\n",
+       "      <td>[]</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>&lt;UID: f51e2e738d6149d6b86305a68a6c678c&gt;</td>\n",
        "      <td>[]</td>\n",
        "      <td></td>\n",
        "    </tr>\n",
@@ -464,11 +710,12 @@
       ],
       "text/plain": [
        "                                        ID                   Tags Description\n",
-       "0  <UID: c2fff91e4de84a9ebf187b6b35b179f9>  [reveal_intersection]            \n",
-       "1  <UID: 6169e798788a46c5a8625f046cda96e2>                  [fpr]            \n",
-       "2  <UID: 7f9ec1f3c36048cc978d31f0778b865b>     [client_items_len]            \n",
-       "3  <UID: 3a6d9e21227e4e9bb6ac69a278be74be>                     []            \n",
-       "4  <UID: 50e1b0268ab24737a26fcb5b7c13cadc>                     []            "
+       "0  <UID: e9f28b44083e4919b5e674e2791a7367>  [reveal_intersection]            \n",
+       "1  <UID: eecc06f86a584b2e978b34fcce490775>                  [fpr]            \n",
+       "2  <UID: 2512e06630c044cba620a27fb3831bb8>     [client_items_len]            \n",
+       "3  <UID: ed1bd1123b9845b4a2b9dcc1a3dbb94e>                     []            \n",
+       "4  <UID: 665a3f6445cd4c49b8130ccc6fa57441>                     []            \n",
+       "5  <UID: f51e2e738d6149d6b86305a68a6c678c>                     []            "
       ]
      },
      "execution_count": 23,
@@ -481,293 +728,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 24,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "duet.requests.add_handler(\n",
-    "    name=\"response\",\n",
-    "    action=\"accept\"\n",
-    ")"
+    "# Goto --------> [Client-Step-3]"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>ID</th>\n",
-       "      <th>Tags</th>\n",
-       "      <th>Description</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>&lt;UID: c2fff91e4de84a9ebf187b6b35b179f9&gt;</td>\n",
-       "      <td>[reveal_intersection]</td>\n",
-       "      <td></td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>&lt;UID: 6169e798788a46c5a8625f046cda96e2&gt;</td>\n",
-       "      <td>[fpr]</td>\n",
-       "      <td></td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>&lt;UID: 7f9ec1f3c36048cc978d31f0778b865b&gt;</td>\n",
-       "      <td>[client_items_len]</td>\n",
-       "      <td></td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>&lt;UID: 3a6d9e21227e4e9bb6ac69a278be74be&gt;</td>\n",
-       "      <td>[]</td>\n",
-       "      <td></td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>&lt;UID: 50e1b0268ab24737a26fcb5b7c13cadc&gt;</td>\n",
-       "      <td>[]</td>\n",
-       "      <td></td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                        ID                   Tags Description\n",
-       "0  <UID: c2fff91e4de84a9ebf187b6b35b179f9>  [reveal_intersection]            \n",
-       "1  <UID: 6169e798788a46c5a8625f046cda96e2>                  [fpr]            \n",
-       "2  <UID: 7f9ec1f3c36048cc978d31f0778b865b>     [client_items_len]            \n",
-       "3  <UID: 3a6d9e21227e4e9bb6ac69a278be74be>                     []            \n",
-       "4  <UID: 50e1b0268ab24737a26fcb5b7c13cadc>                     []            "
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "duet.store.pandas"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "request_ptr = duet.store[\"50e1b0268ab24737a26fcb5b7c13cadc\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "_data_object2proto <class 'proto.core.store.store_object_pb2.StorableObject'> <class 'proto.core.store.store_object_pb2.StorableObject'>\n"
-     ]
-    }
-   ],
-   "source": [
-    "request_wrapper = request_ptr.get(delete_obj=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "openmined_psi.GenerateProtobufWrapper.<locals>.ProtobufWrapper"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "type(request_wrapper)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "request = request_wrapper.value"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "proto.core.store.store_object_pb2.StorableObject"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "type(request)     "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "google.protobuf.any_pb2.Any"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "type(request.data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "bytes"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "type(request.data.value)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "req = psi.Request()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "35105"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "req.ParseFromString(request.data.value)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "encrypted_elements: \"openmined_psi.RequestProtobufWrapper\""
-      ]
-     },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "req"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "RuntimeError",
-     "evalue": "ECGroup::CreateECPoint(string) - Could not decode point.\nerror:0f00006d:elliptic curve routines:OPENSSL_internal:INVALID_ENCODING",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m-------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mRuntimeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-36-74e58554a12c>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mresponse\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mserver\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mProcessRequest\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mreq\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/.local/share/virtualenvs/PySyft-lHlz_cKe/lib/python3.8/site-packages/openmined_psi/__init__.py\u001b[0m in \u001b[0;36mProcessRequest\u001b[0;34m(self, client_request)\u001b[0m\n\u001b[1;32m    164\u001b[0m         \"\"\"\n\u001b[1;32m    165\u001b[0m         \u001b[0minterm_req\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpsi\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcpp_proto_request\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mLoad\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mclient_request\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSerializeToString\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 166\u001b[0;31m         \u001b[0minterm_resp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mProcessRequest\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minterm_req\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msave\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    167\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    168\u001b[0m         \u001b[0mresp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mResponse\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mRuntimeError\u001b[0m: ECGroup::CreateECPoint(string) - Could not decode point.\nerror:0f00006d:elliptic curve routines:OPENSSL_internal:INVALID_ENCODING"
-     ]
-    }
-   ],
-   "source": [
-    "response = server.ProcessRequest(req)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -786,7 +751,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
One problem in [this commit](https://github.com/OpenMined/PySyft/pull/4879/commits/30a32ecddb82007080ad055d55be3673c560f5fc) is that when the server get the `request_wrapper` via Duet, the `request` proto extracted from it can not be used for the server to create response, there is error when do this. This PR aims to resolve this error. The code change is self explained.

And I do some reformation to the jupyter notebooks.

Run the notebooks, and you can see we now can run the entire PSI process successfully.